### PR TITLE
Update ngx-platform-info.service.ts

### DIFF
--- a/projects/ngx-platform-info/src/lib/ngx-platform-info.service.ts
+++ b/projects/ngx-platform-info/src/lib/ngx-platform-info.service.ts
@@ -215,14 +215,14 @@ export class NgxPlatformInfo {
             break;
 
         case 'Android':
-            osVersionData = /Android ([\.\_\d]+)/.exec(nAgt);
+            let osVersionData = /Android ([\.\_\d]+)/.exec(nAgt);
             if(osVersionData && osVersionData.length > 1) {
               osVersion = osVersionData[1];
             }
             break;
 
         case 'iOS':
-            osVersionData = /OS (\d+)_(\d+)_?(\d+)?/.exec(nVer);
+            let osVersionData = /OS (\d+)_(\d+)_?(\d+)?/.exec(nVer);
             if(osVersionData && osVersionData.length > 2) {
               osVersion = osVersionData[1] + '.' + osVersionData[2] + '.' + (osVersionData[3] || 0+'');
             }


### PR DESCRIPTION
In line #218 and #225 osVersionData is not declared, so getting an error while using this service in mobile. 
ReferenceError: Cannot access 'osVersionData' before initialization
    at NgxPlatformInfo._extractPlatformInfo (ngx-platform-info.js.)

Could these changes be made?